### PR TITLE
Integrate Eureka Server and Clients for Service Discovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<description>Pharmacy All Microservice Service Registry</description>
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2021.0.4</spring-cloud.version>
+		<spring-cloud.version>2023.0.1</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/src/main/java/com/lifepill/service_registry/ServiceRegistryApplication.java
+++ b/src/main/java/com/lifepill/service_registry/ServiceRegistryApplication.java
@@ -2,8 +2,10 @@ package com.lifepill.service_registry;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
 
 @SpringBootApplication
+@EnableEurekaServer
 public class ServiceRegistryApplication {
 
 	public static void main(String[] args) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=service-registry

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+spring:
+  application:
+    name: SERVICE-REGISTRY
+
+server:
+    port: 8761
+
+#To disable eureka client behaviours
+eureka:
+  client:
+    registerWithEureka: false
+    fetchRegistry: false
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/


### PR DESCRIPTION
### Title
Integrate Eureka Server and Clients for Service Discovery

### Pull Request Description

This PR introduces Eureka Server and Eureka Client integration into the POS system and SupplierService to enable service discovery. The changes include configuring Eureka Server, adding Eureka Client dependencies, and updating configurations for both services.

### Changes Made

1. **Eureka Server Configuration**
   - Set up a new Eureka Server application.
   - Added Eureka Server dependencies in the POM file.

2. **Eureka Client Configuration**
   - Added Eureka Client dependencies in the POM files for POS system and SupplierService.
   - Updated application properties for Eureka client configuration.

3. **Service Registration**
   - Updated both services to register themselves with Eureka Server.

### Detailed Description

#### Eureka Server

1. **Create Eureka Server Application**

- Create a new Spring Boot application for Eureka Server.

```java
package com.lifepill.eurekaserver;

import org.springframework.boot.SpringApplication;
import org.springframework.boot.autoconfigure.SpringBootApplication;
import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;

@SpringBootApplication
@EnableEurekaServer
public class EurekaServerApplication {
    public static void main(String[] args) {
        SpringApplication.run(EurekaServerApplication.class, args);
    }
}
```

2. **POM File for Eureka Server**

- Add the following dependencies to the Eureka Server `pom.xml`:

```xml
<dependencies>
    <dependency>
        <groupId>org.springframework.cloud</groupId>
        <artifactId>spring-cloud-starter-netflix-eureka-server</artifactId>
    </dependency>
    <dependency>
        <groupId>org.springframework.boot</groupId>
        <artifactId>spring-boot-starter-web</artifactId>
    </dependency>
</dependencies>
```

3. **Application Properties for Eureka Server**

- Configure `application.properties` for the Eureka Server:

```properties
server.port=8761
eureka.client.register-with-eureka=false
eureka.client.fetch-registry=false
eureka.instance.hostname=localhost
```

#### Eureka Client

1. **POM File for Eureka Clients**

- Add the following dependencies to the `pom.xml` files of both the POS system and SupplierService:

```xml
<dependency>
    <groupId>org.springframework.cloud</groupId>
    <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
</dependency>
<dependency>
    <groupId>org.springframework.cloud</groupId>
    <artifactId>spring-cloud-starter-openfeign</artifactId>
</dependency>
```

2. **Application Properties for Eureka Clients**

- Update the `application.properties` for both services to configure Eureka client settings:

**POS System `application.properties`**:
```properties
spring.application.name=pos-system
eureka.client.service-url.defaultZone=http://localhost:8761/eureka/
```

**SupplierService `application.properties`**:
```properties
spring.application.name=supplier-service
eureka.client.service-url.defaultZone=http://localhost:8761/eureka/
```

3. **Enable Eureka Client in Applications**

- Annotate the main application classes of both services with `@EnableEurekaClient`:

**POS System Main Application**:
```java
package com.lifepill.possystem;

import org.springframework.boot.SpringApplication;
import org.springframework.boot.autoconfigure.SpringBootApplication;
import org.springframework.cloud.netflix.eureka.EnableEurekaClient;

@SpringBootApplication
@EnableEurekaClient
public class PosSystemApplication {
    public static void main(String[] args) {
        SpringApplication.run(PosSystemApplication.class, args);
    }
}
```

**SupplierService Main Application**:
```java
package com.lifepill.supplierservice;

import org.springframework.boot.SpringApplication;
import org.springframework.boot.autoconfigure.SpringBootApplication;
import org.springframework.cloud.netflix.eureka.EnableEurekaClient;

@SpringBootApplication
@EnableEurekaClient
public class SupplierServiceApplication {
    public static void main(String[] args) {
        SpringApplication.run(SupplierServiceApplication.class, args);
    }
}
```

4. **Update Feign Client Configuration**

- Update the `APIClient` interface in the POS system to use Eureka service names instead of hard-coded URLs:

```java
package com.lifepill.possystem.service;

import com.lifepill.possystem.dto.SupplierAndSupplierCompanyDTO;
import org.springframework.cloud.openfeign.FeignClient;
import org.springframework.web.bind.annotation.GetMapping;
import org.springframework.web.bind.annotation.PathVariable;

@FeignClient(name = "supplier-service")
public interface APIClient {

    @GetMapping(path = "/supplier/get-supplier-with-company/{supplierId}")
    SupplierAndSupplierCompanyDTO getSupplierAndCompanyBySupplierId(
            @PathVariable("supplierId") long supplierId
    );
}
```

### Testing

- Ensure that the Eureka Server starts correctly and is accessible at `http://localhost:8761`.
- Verify that both POS system and SupplierService register themselves with the Eureka Server.
- Test inter-service communication using Feign clients to ensure they resolve service instances via Eureka.

### Checklist
- [x] Create Eureka Server application.
- [x] Add Eureka Server dependencies.
- [x] Configure `application.properties` for Eureka Server.
- [x] Add Eureka Client dependencies to POS system and SupplierService.
- [x] Configure `application.properties` for Eureka Clients.
- [x] Annotate main application classes with `@EnableEurekaClient`.
- [x] Update Feign client configuration to use service names.
- [x] Test service registration with Eureka Server.
- [x] Validate inter-service communication via Eureka.

## ScreenShot
<img width="1709" alt="Screenshot 2024-05-25 at 2 31 26 AM" src="https://github.com/Life-Pill/service-registry/assets/123730262/d2e00b69-1c5e-4cdd-8975-4445c259ce75">

### Additional Notes

- Make sure the Eureka Server is running before starting the client services.
- The base URL for Feign clients is now determined by the Eureka Server, facilitating dynamic service discovery and load balancing.
- This setup provides a robust architecture for service discovery and inter-service communication.

---
Best regards,
Pramitha Jayasooriya,
Backend Developer at LifePill
https://pramithamj.me